### PR TITLE
Fixed the appdata.xml install location

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -16,4 +16,4 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/com.github.philip-scott.spice-up.svg
 
 # install the appdata
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/com.github.philip-scott.spice-up.appdata.xml
-        DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/metainfo/)
+        DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/appdata/)


### PR DESCRIPTION
A regression introduced by https://github.com/Philip-Scott/Spice-up/pull/58. The `metainfo` folder is only for smaller addons like plugins or fonts.