### PR TITLE
Correcting MimeType in .desktop file.

### DIFF
--- a/data/com.github.philip-scott.spice-up.desktop
+++ b/data/com.github.philip-scott.spice-up.desktop
@@ -7,7 +7,7 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Office;Presentation;
-MimeType=application-x-spiceup;
+MimeType=application/x-spiceup;
 Actions=AboutDialog;
 
 [Desktop Action AboutDialog]


### PR DESCRIPTION
Opening a presentation from Files didn't open Spice-Up but said there was no application installed to open this kind of files. This change, followed by calling `sudo update-desktop-database` fixed it.