### PR TITLE
Use a more theme-agnostic stylesheet 

### DIFF
--- a/data/stylesheet.css
+++ b/data/stylesheet.css
@@ -1,13 +1,3 @@
-/*
-You can type here any CSS rule recognized by GTK+.
-You can temporarily disable this custom CSS by clicking on the “Pause” button above.
-
-Changes are applied instantly and globally, for the whole application.
-*/
-
-@define-color SpicePrimaryBackground #333435;
-@define-color SpiceSlideBackground #2A2B2C;
-@define-color SpiceSlideBackgroundSelected #222324;
 @define-color colorPrimary #2C2D2E;
 
 .slide-list {

--- a/data/stylesheet.css
+++ b/data/stylesheet.css
@@ -1,19 +1,28 @@
+/*
+You can type here any CSS rule recognized by GTK+.
+You can temporarily disable this custom CSS by clicking on the “Pause” button above.
+
+Changes are applied instantly and globally, for the whole application.
+*/
+
 @define-color SpicePrimaryBackground #333435;
 @define-color SpiceSlideBackground #2A2B2C;
 @define-color SpiceSlideBackgroundSelected #222324;
 @define-color colorPrimary #2C2D2E;
+
 .slide-list {
-    background-color: @SpiceSlideBackground;
-    border-right: solid 1px rgba(0,0,0,0.75)
+    background-color: shade(@bg_color, 0.75);
+    border-right: solid 1px rgba(0,0,0,0.75);
 }
 
-.slide-list .list-row:selected {
+.slide-list row:selected {
     box-shadow: inset 0px 24px 10px -6px rgba(0,0,0, 0.53);
-    background-color: @SpiceSlideBackgroundSelected;
+    background-color: shade(@bg_color, 0.5);
 }
+
 
 .new.slide {
-    background-color: @SpicePrimaryBackground;
+    background-color: rgba(0,0,0,0.2);
     border-radius: 4px;
     border-color: black;
 }
@@ -25,10 +34,6 @@
 
 .canvas, frame {
     border-radius: 6px;
-}
-
-.background {
-    background-color: @SpicePrimaryBackground;
 }
 
 .view.canvas {
@@ -52,16 +57,13 @@ GtkTextView:selected, textview {
 }
 
 .spice-dynamic-toolbar {
-     background-image: linear-gradient(to bottom, #222324, #292A2B);
+     background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.3));
 }
 
 GtkToggleButton,.spice,
 .spice-dynamic-toolbar .spice {
     color: #DEDEDE;
-    background:
-    linear-gradient(
-        to bottom, shade (@SpicePrimaryBackground, 1.1), shade (@SpicePrimaryBackground, 1.1)
-    );
+    background-color: rgba(255,255,255,0.05);
     padding: 2px 8px;
     border-radius: 4px;
     border-width: 1px;
@@ -81,11 +83,7 @@ background: none;
 }
 
 .spice.suggested-action {
-    background-image:
-    linear-gradient(to bottom,
-        shade (@selected_bg_color, 1.1),
-        shade (@selected_bg_color, 0.9)
-    );
+    background-color: rgba(0,255,0, 0.3);
 }
 
 .spice.suggested-action:active,

--- a/data/stylesheet.css
+++ b/data/stylesheet.css
@@ -82,10 +82,6 @@ background: none;
         0 1px 0 0 alpha (@bg_highlight_color, 0.3);
 }
 
-.spice.suggested-action {
-    background-color: rgba(0,255,0, 0.3);
-}
-
 .spice.suggested-action:active,
 .spice.suggested-action:selected {
     background: shade (@selected_bg_color, 0.8);


### PR DESCRIPTION
The new `data/stylesheet.css` uses fewer hardcoded values which allows Spice-Up to look more at-home with a wider variety of themes. It doesn't affect the look and feel of the app much when using the default elementary theme, but it looks far more at home while using the Pop GTK theme, as an example.