### PR TITLE
Font search

### DIFF
--- a/src/Widgets/EntryCombo.vala
+++ b/src/Widgets/EntryCombo.vala
@@ -88,7 +88,7 @@ public class Spice.EntryCombo : Gtk.Box {
     private bool strict_signal = false;
 
     // If strict_signal == true, it will only send activated if the entry is the same as a value on the list
-    public EntryCombo (bool strict_signal = false, bool alphabetize = false) {
+    public EntryCombo (bool strict_signal = false, bool alphabetize = false, bool searchable = false) {
         this.strict_signal = strict_signal;
 
         row_map = new Gee.HashMap<string, Gtk.ListBoxRow> ();
@@ -119,7 +119,8 @@ public class Spice.EntryCombo : Gtk.Box {
         scroll = new Gtk.ScrolledWindow (null, null);
         scroll.hscrollbar_policy = Gtk.PolicyType.NEVER;
         scroll.vscrollbar_policy = Gtk.PolicyType.NEVER;
-
+        scroll.add (listbox);
+        
         popover = new Gtk.Popover (button);
         popover.position = Gtk.PositionType.BOTTOM;
 
@@ -162,8 +163,24 @@ public class Spice.EntryCombo : Gtk.Box {
             });
         }
 
-        scroll.add (listbox);
-        popover.add (scroll);
+        var popover_content = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
+        
+        if (searchable) {
+            var search_entry = new Gtk.SearchEntry ();
+            search_entry.margin = 6;
+            
+            listbox.set_filter_func ((row) => {
+                return (((Gtk.Label) row.get_child ()).label.down ().contains (search_entry.text.down ().strip ()));
+            });
+            
+            search_entry.search_changed.connect (() => {
+                listbox.invalidate_filter ();
+            });
+            popover_content.add (search_entry);
+        }
+        
+        popover_content.add (scroll);
+        popover.add (popover_content);
 
         entry_button_stack.add_named (entry, "entry");
         entry_button_stack.add_named (entry_substitute, "button");

--- a/src/Widgets/EntryCombo.vala
+++ b/src/Widgets/EntryCombo.vala
@@ -120,7 +120,7 @@ public class Spice.EntryCombo : Gtk.Box {
         scroll.hscrollbar_policy = Gtk.PolicyType.NEVER;
         scroll.vscrollbar_policy = Gtk.PolicyType.NEVER;
         scroll.add (listbox);
-        
+
         popover = new Gtk.Popover (button);
         popover.position = Gtk.PositionType.BOTTOM;
 
@@ -164,21 +164,21 @@ public class Spice.EntryCombo : Gtk.Box {
         }
 
         var popover_content = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);
-        
+
         if (searchable) {
             var search_entry = new Gtk.SearchEntry ();
             search_entry.margin = 6;
-            
+
             listbox.set_filter_func ((row) => {
                 return (((Gtk.Label) row.get_child ()).label.down ().contains (search_entry.text.down ().strip ()));
             });
-            
+
             search_entry.search_changed.connect (() => {
                 listbox.invalidate_filter ();
             });
             popover_content.add (search_entry);
         }
-        
+
         popover_content.add (scroll);
         popover.add (popover_content);
 

--- a/src/Widgets/Toolbars/TextBar.vala
+++ b/src/Widgets/Toolbars/TextBar.vala
@@ -53,7 +53,7 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
 
         family_cache = new Gee.HashMap<string, Pango.FontFamily> ();
         face_cache = new Gee.HashMap<string, Array<Pango.FontFace>> ();
-        font_button = new Spice.EntryCombo (true, true);
+        font_button = new Spice.EntryCombo (true, true, true);
         font_button.set_tooltip_text (_("Font"));
         create_pango_context ().list_families (out families);
 


### PR DESCRIPTION
Fixes #107 

Changes made in this pull request: 
- Added `bool searchable` to the constructor.
- if `searchable = true`, a `SearchEntry` appears, which filters the `ListBox`.
- Made the font `EntryCombo` searchable.

This behavior can now be easily implemented into existing `EntryCombo`'s, just change the instance creation from, for example:
   ` new EntryCombo (true, true)`
to
   ` new EntryCombo (true, true, true)`
