### PR TITLE
TextBar.vala: Make font-style EntryCombo uneditable

### DIFF
--- a/src/Widgets/Toolbars/TextBar.vala
+++ b/src/Widgets/Toolbars/TextBar.vala
@@ -63,6 +63,7 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
         face_cache = new Gee.HashMap<string, Array<Pango.FontFace>> ();
         font_button = new Spice.EntryCombo (true, true, true);
         font_button.set_tooltip_text (_("Font"));
+        font_button.editable = false;
         create_pango_context ().list_families (out families);
 
         foreach (var family in families) {


### PR DESCRIPTION
Make the font style picker uneditable, because user should choose from a list of predefined options, not enter his own.
