### PR TITLE
TextBar.vala: Added representative styling to the font style picker.

### DIFF
--- a/src/Widgets/Toolbars/TextBar.vala
+++ b/src/Widgets/Toolbars/TextBar.vala
@@ -49,6 +49,14 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
         }
     """;
     #endif
+    
+    const string FONT_STYLE_CSS = """
+        .label {
+            font-style: %s;
+            font-weight: %i;
+            
+        }
+    """;
 
     construct {
         text_color_button = new Spice.ColorPicker ();
@@ -243,7 +251,34 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
             font_type.clear_all ();
 
             for (int i = 0; i < font_faces.length ; i++) {
-                font_type.add_entry (font_faces.index (i).get_face_name ());
+                var font_face = font_faces.index (i);
+                var entry = font_type.add_entry (font_face.get_face_name ());
+
+                var description = font_face.describe();
+                string style = null;
+                switch (description.get_style ()) {
+                   case Pango.Style.NORMAL: style = "normal"; break;
+                   case Pango.Style.OBLIQUE: style = "oblique"; break;
+                   case Pango.Style.ITALIC: style = "italic"; break;
+                }
+
+                int weight = 400;
+                switch (description.get_weight ()) {
+                    case Pango.Weight.THIN: weight = 100; break;
+                    case Pango.Weight.ULTRALIGHT: weight = 200; break;
+                    case Pango.Weight.LIGHT: weight = 300; break;
+                    case Pango.Weight.SEMILIGHT: weight = 350; break;
+                    case Pango.Weight.BOOK: weight = 380; break;
+                    case Pango.Weight.NORMAL: weight = 400; break;
+                    case Pango.Weight.MEDIUM: weight = 500; break;
+                    case Pango.Weight.SEMIBOLD: weight = 600; break;
+                    case Pango.Weight.BOLD: weight = 700; break;
+                    case Pango.Weight.ULTRABOLD: weight = 800; break;
+                    case Pango.Weight.HEAVY: weight = 900; break;
+                    case Pango.Weight.ULTRAHEAVY: weight = 1000; break;
+                }
+
+                Utils.set_style (entry, FONT_STYLE_CSS.printf (style, weight));
             }
         }
     }

--- a/src/Widgets/Toolbars/TextBar.vala
+++ b/src/Widgets/Toolbars/TextBar.vala
@@ -266,7 +266,7 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
                 var entry = font_type.add_entry (font_face.get_face_name ());
 
                 var description = font_face.describe();
-                string style = null;
+                string style = "normal";
                 switch (description.get_style ()) {
                    case Pango.Style.NORMAL: style = "normal"; break;
                    case Pango.Style.OBLIQUE: style = "oblique"; break;

--- a/src/Widgets/Toolbars/TextBar.vala
+++ b/src/Widgets/Toolbars/TextBar.vala
@@ -41,6 +41,14 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
             font: 16px '%s';
         }
     """;
+
+    const string FONT_STYLE_CSS = """
+        label {
+            font: 16px '%s';
+            font-style: %s;
+            font-weight: %i;
+        }
+    """;
     #else
     const string TEXT_STYLE_CSS = """
         .label {
@@ -48,15 +56,16 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
             font-size: 14px;
         }
     """;
-    #endif
-    
+
     const string FONT_STYLE_CSS = """
         .label {
+            font: %s;
+            font-size: 14px;
             font-style: %s;
             font-weight: %i;
-            
         }
     """;
+    #endif
 
     construct {
         text_color_button = new Spice.ColorPicker ();
@@ -249,6 +258,8 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
             }
 
             font_type.clear_all ();
+            
+            var family_name = family_cache.get (key).get_name ();
 
             for (int i = 0; i < font_faces.length ; i++) {
                 var font_face = font_faces.index (i);
@@ -278,7 +289,7 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
                     case Pango.Weight.ULTRAHEAVY: weight = 1000; break;
                 }
 
-                Utils.set_style (entry, FONT_STYLE_CSS.printf (style, weight));
+                Utils.set_style (entry, FONT_STYLE_CSS.printf (family_name, style, weight));
             }
         }
     }

--- a/src/Widgets/Toolbars/TextBar.vala
+++ b/src/Widgets/Toolbars/TextBar.vala
@@ -44,8 +44,7 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
 
     const string FONT_STYLE_CSS = """
         label {
-            font: 16px '%s';
-            font-style: %s;
+            font: 16px '%s' %s;
             font-weight: %i;
         }
     """;

--- a/src/Widgets/Toolbars/TextBar.vala
+++ b/src/Widgets/Toolbars/TextBar.vala
@@ -44,8 +44,9 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
 
     const string FONT_STYLE_CSS = """
         label {
-            font: 16px '%s' %s;
-            font-weight: %i;
+            font: %i '%s' 16px %s;
+            font: 16px ;
+            font-weight: ;
         }
     """;
     #else
@@ -287,8 +288,11 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
                     case Pango.Weight.HEAVY: weight = 900; break;
                     case Pango.Weight.ULTRAHEAVY: weight = 1000; break;
                 }
-
+                #if GTK_3_222
+                Utils.set_style (entry, FONT_STYLE_CSS.printf (weight, style, family_name));
+                #else
                 Utils.set_style (entry, FONT_STYLE_CSS.printf (family_name, style, weight));
+                #endif
             }
         }
     }


### PR DESCRIPTION
Fixes #187 

Changes made in this pull request: 
- Added CSS template into which actual values are inputted.
- Took information from the `font_face` about its styling.
- Applied given styling.

I have something I'm not sure about with this pull request:

1. Should I also insert precompilation annotation about GTK version? (I also noticed that there is no dot at one of the previous selectors, is that intentional?)

2. Should we also apply the current font-face to the list items? Like, so it could be "previewed"? 
