### PR TITLE
Remove about option from desktop entry

### DIFF
--- a/data/com.github.philip-scott.spice-up.desktop
+++ b/data/com.github.philip-scott.spice-up.desktop
@@ -10,10 +10,3 @@ Type=Application
 StartupNotify=true
 Categories=Office;Presentation;
 MimeType=application/x-spiceup;
-Actions=AboutDialog;
-
-[Desktop Action AboutDialog]
-Exec=com.github.philip-scott.spice-up --about
-Name=About Spice-Up
-Name[pt_BR]=Sobre o Spice-Up
-Name[fr]=À propos de Spice-Up


### PR DESCRIPTION
Changes made in this pull request: 
- Removes about option from the desktop entry - `com.github.philip-scott.spice-up --about` doesn't do anything so the launcher option gives no output