### PR TITLE
Remove spice class and save a lot of work in button css

### DIFF
--- a/data/stylesheet.css
+++ b/data/stylesheet.css
@@ -76,59 +76,10 @@ GtkTextView:selected, textview:selected {
      background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.3));
 }
 
-GtkToggleButton.spice, .spice,
-.spice-dynamic-toolbar .spice {
-    color: #DEDEDE;
-    background-color: rgba(255,255,255,0.05);
-    padding: 2px 8px;
-    border-radius: 4px;
-    border-width: 1px;
-    box-shadow: 0px 0px 1px 1px rgba (0,0,0, 0.1);
-}
-
-.spice:active,
-.spice:checked,
-.spice:selected {
-    background: none;
-    background-color: alpha (#000, 0.05);
-
-    border-color: alpha (#000, 0.27);
-    box-shadow:
-        inset 0 0 0 1px alpha (#000, 0.05),
-        0 1px 0 0 alpha (@bg_highlight_color, 0.3);
-}
-
-.spice.suggested-action:active,
-.spice.suggested-action:selected {
-    background: shade (@selected_bg_color, 0.8);
-    border-color: shade (@selected_bg_color, 0.8);
-}
-
-.spice:disabled, .spice:disabled image {
-    background-image: none;
-    background-color: transparent;
-    color: @insensitive_color;
-}
-
-.linked .spice {
-    border-left-width: 0;
-    border-radius: 0;
-}
-
-.linked .spice:first-child {
-    border-width: 1px;
-    border-bottom-right-radius: 0;
-    border-top-right-radius: 0;
-    border-bottom-left-radius: 4px;
-    border-top-left-radius: 4px;
-}
-
-.linked .spice:last-child {
-    border-left-width: 0;
-    border-bottom-right-radius: 4px;
-    border-top-right-radius: 4px;
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
+.spice-dynamic-toolbar button {
+    background-color: @bg_color;
+    padding: 0;
+    min-width: 32px;
 }
 
 .spice-scale {

--- a/src/Widgets/Toolbars/CommonBar.vala
+++ b/src/Widgets/Toolbars/CommonBar.vala
@@ -36,7 +36,6 @@ public class Spice.Widgets.CommonToolbar : Spice.Widgets.Toolbar {
 
         delete_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
         delete_button.set_tooltip_text (_("Delete"));
-        delete_button.get_style_context ().add_class ("spice");
 
         delete_button.clicked.connect (() => {
             if (this.item != null) {
@@ -50,7 +49,6 @@ public class Spice.Widgets.CommonToolbar : Spice.Widgets.Toolbar {
         });
 
         clone_button = new Gtk.Button.from_icon_name ("edit-copy-symbolic", Gtk.IconSize.MENU);
-        clone_button.get_style_context ().add_class ("spice");
         clone_button.set_tooltip_text (_("Clone"));
 
         clone_button.clicked.connect (() => {
@@ -79,11 +77,9 @@ public class Spice.Widgets.CommonToolbar : Spice.Widgets.Toolbar {
         });
 
         to_top = new Gtk.Button.from_icon_name ("go-up-symbolic", Gtk.IconSize.MENU);
-        to_top.get_style_context ().add_class ("spice");
         to_top.set_tooltip_text (_("Bring forward"));
 
         to_bottom = new Gtk.Button.from_icon_name ("go-down-symbolic", Gtk.IconSize.MENU);
-        to_bottom.get_style_context ().add_class ("spice");
         to_bottom.set_tooltip_text (_("Send backward"));
 
         var position_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);

--- a/src/Widgets/Toolbars/ImageBar.vala
+++ b/src/Widgets/Toolbars/ImageBar.vala
@@ -27,14 +27,10 @@ public class Spice.Widgets.ImageToolbar : Spice.Widgets.Toolbar {
         open_with = new Gtk.MenuButton ();
         open_with.add (new Gtk.Image.from_icon_name ("applications-graphics-symbolic", Gtk.IconSize.MENU));
         open_with.set_tooltip_text (_("Edit image with…"));
-        open_with.get_style_context ().add_class ("spice");
-        open_with.get_style_context ().add_class ("image-button");
 
         replace_image = new Gtk.Button ();
         replace_image.add (new Gtk.Image.from_icon_name ("document-new-symbolic", Gtk.IconSize.MENU));
         replace_image.set_tooltip_text (_("Replace Image…"));
-        replace_image.get_style_context ().add_class ("spice");
-        replace_image.get_style_context ().add_class ("image-button");
 
         replace_image.clicked.connect (() => {
             var file = Spice.Services.FileManager.open_image ();

--- a/src/Widgets/Toolbars/ShapeBar.vala
+++ b/src/Widgets/Toolbars/ShapeBar.vala
@@ -33,7 +33,6 @@ public class Spice.Widgets.ShapeToolbar : Spice.Widgets.Toolbar {
         border_radius.margin = 12;
 
         var border_radius_button = new Gtk.Button.from_icon_name ("applications-engineering-symbolic", Gtk.IconSize.MENU);
-        border_radius_button.get_style_context ().add_class ("spice");
         border_radius_button.set_tooltip_text (_("Roundness"));
 
         var border_radius_popover = new Gtk.Popover (border_radius_button);

--- a/src/Widgets/Toolbars/TextBar.vala
+++ b/src/Widgets/Toolbars/TextBar.vala
@@ -99,7 +99,6 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
         align_button_image = new Gtk.Image.from_icon_name ("format-justify-fill-symbolic", Gtk.IconSize.MENU);
 
         var align_button = new Gtk.Button ();
-        align_button.get_style_context ().add_class ("spice");
         align_button.set_tooltip_text (_("Align"));
         align_button.add (align_button_image);
 
@@ -127,10 +126,6 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
         justification.append_icon ("format-justify-right-symbolic", Gtk.IconSize.MENU);
         justification.append_icon ("format-justify-fill-symbolic", Gtk.IconSize.MENU);
 
-        foreach (var child in justification.get_children ()) {
-            child.get_style_context ().add_class ("spice");
-        }
-
         align = new Granite.Widgets.ModeButton ();
         align.mode_added.connect ((index, widget) => {
             widget.set_tooltip_text (ALIGN_TRANSLATIONS[index]);
@@ -140,10 +135,6 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
         align.append (new Gtk.Image.from_resource ("/com/github/philip-scott/spice-up/align-top-symbolic"));
         align.append (new Gtk.Image.from_resource ("/com/github/philip-scott/spice-up/align-middle-symbolic"));
         align.append (new Gtk.Image.from_resource ("/com/github/philip-scott/spice-up/align-bottom-symbolic"));
-
-        foreach (var child in align.get_children ()) {
-            child.get_style_context ().add_class ("spice");
-        }
 
         add (text_color_button);
         add (font_button);


### PR DESCRIPTION
Much less work. Looks like this:

![screenshot from 2018-08-24 15 03 51 2x](https://user-images.githubusercontent.com/7277719/44609980-eef54680-a7ae-11e8-97a0-6d075b522b81.png)

Old one looks like this:

![screenshot from 2018-08-24 15 04 30 2x](https://user-images.githubusercontent.com/7277719/44610000-0c2a1500-a7af-11e8-98fb-221669105878.png)

