### PR TITLE
Fix compilation errors on Manjaro

### DIFF
--- a/src/Services/Slide.vala
+++ b/src/Services/Slide.vala
@@ -40,8 +40,6 @@ public class Spice.Slide : Object {
             canvas.visible = value;
             visible_changed (value);
         }
-
-        default = true;
     }
 
     public Slide (Json.Object? save_data = null) {

--- a/src/Widgets/Canvas.vala
+++ b/src/Widgets/Canvas.vala
@@ -28,7 +28,7 @@ public class Spice.Canvas : Gtk.Overlay {
     public signal void next_slide ();
     public signal void previous_slide ();
 
-    private double _current_ratio;
+    private double _current_ratio = 1.0f;
     public double current_ratio {
         get {
             return _current_ratio;
@@ -40,8 +40,6 @@ public class Spice.Canvas : Gtk.Overlay {
                 ratio_changed (current_ratio);
             }
         }
-
-        default = 1.0f;
     }
 
     public double current_allocated_width = 0;

--- a/src/Widgets/PresenterView.vala
+++ b/src/Widgets/PresenterView.vala
@@ -31,9 +31,8 @@ public class Spice.PresenterWindow : Gtk.Window {
 
     Clock clock;
 
-    private int _font_size;
+    private int _font_size = 12;
     private int font_size {
-        default = 12;
         get {
             return _font_size;
         }

--- a/src/Window.vala
+++ b/src/Window.vala
@@ -32,11 +32,11 @@ public class Spice.Window : Gtk.ApplicationWindow {
             } else {
                 aspect_frame.margin = 24;
             }
-        } default = false;
+        }
     }
 
     private bool notification_shown = false;
-    private bool is_full_;
+    private bool is_full_ = false;
 
     private Spice.Headerbar headerbar;
     private Spice.SlideManager slide_manager;


### PR DESCRIPTION
## Property with custom get and/or set mutator cannot have default value

Fixes #235 

Changes made in this pull request: 
- src/Window.vala:25.5-25.29: error: Property `Spice.Window.is_fullscreen'
- src/Widgets/Canvas.vala:32.5-32.31: error: Property `Spice.Canvas.current_ratio'
- src/Services/Slide.vala:35.5-35.23: error: Property `Spice.Slide.visible'
- src/Widgets/PresenterView.vala:35.5-35.25: error: Property `Spice.PresenterWindow.font_size'