### PR TITLE
New file format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set (PKG_DEPS
     gudev-1.0
     libevdev
     libsoup-2.4
+    libarchive
 )
 
 set (VALA_DEPS
@@ -39,6 +40,7 @@ set (VALA_DEPS
     libevdev
     linux
     libsoup-2.4
+    libarchive
 )
 
 

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,8 @@ Build-Depends: cmake,
                libjson-glib-dev,
                libgudev-1.0-dev,
                libevdev-dev,
-               libsoup2.4-dev
+               libsoup2.4-dev,
+               libarchive-dev
 
 Standards-Version: 3.9.6
 Package: com.github.philip-scott.spice-up

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,9 @@ vala_precompile(VALA_C
   Services/Utils.vala
   Services/GamepadSlideController.vala
 
+  Services/FileFormat/SpiceUpFile.vala
+  Services/FileFormat/ZipArchiveHandler.vala
+
   Widgets/Canvas.vala
   Widgets/EntryCombo.vala
   Widgets/Headerbar.vala

--- a/src/Services/Clipboard.vala
+++ b/src/Services/Clipboard.vala
@@ -102,6 +102,7 @@ public class Spice.Clipboard {
         Gtk.Clipboard clipboard = Gtk.Clipboard.get_default (Gdk.Display.get_default ());
 
         object_data = clone (object);
+        print (object_data);
 
         if (object is Spice.TextItem) {
             debug ("set text target list");

--- a/src/Services/Clipboard.vala
+++ b/src/Services/Clipboard.vala
@@ -154,7 +154,7 @@ public class Spice.Clipboard {
                 var root_object = Utils.get_json_object (data);
                 if (root_object == null) return;
 
-                if (root_object.has_member ("preview")) {
+                if (root_object.has_member ("items")) {
                     manager.new_slide (root_object, true);
                 } else {
                     var item = Utils.canvas_item_from_data (root_object, manager.current_slide.canvas);

--- a/src/Services/Clipboard.vala
+++ b/src/Services/Clipboard.vala
@@ -158,11 +158,13 @@ public class Spice.Clipboard {
                     manager.new_slide (root_object, true);
                 } else {
                     var item = Utils.canvas_item_from_data (root_object, manager.current_slide.canvas);
-                    manager.current_slide.add_item (item, true, true);
 
                     if (item is Spice.ImageItem) {
+                        // This clones the image file
                         (item as Spice.ImageItem).image.copy_to_another_file ();
                     }
+
+                    manager.current_slide.add_item (item, true, true);
                 }
             });
             return;

--- a/src/Services/Clipboard.vala
+++ b/src/Services/Clipboard.vala
@@ -159,6 +159,10 @@ public class Spice.Clipboard {
                 } else {
                     var item = Utils.canvas_item_from_data (root_object, manager.current_slide.canvas);
                     manager.current_slide.add_item (item, true, true);
+
+                    if (item is Spice.ImageItem) {
+                        (item as Spice.ImageItem).image.copy_to_another_file ();
+                    }
                 }
             });
             return;

--- a/src/Services/Clipboard.vala
+++ b/src/Services/Clipboard.vala
@@ -158,12 +158,6 @@ public class Spice.Clipboard {
                     manager.new_slide (root_object, true);
                 } else {
                     var item = Utils.canvas_item_from_data (root_object, manager.current_slide.canvas);
-
-                    if (item is Spice.ImageItem) {
-                        // This clones the image file
-                        (item as Spice.ImageItem).image.copy_to_another_file ();
-                    }
-
                     manager.current_slide.add_item (item, true, true);
                 }
             });

--- a/src/Services/FileFormat/Converter.vala
+++ b/src/Services/FileFormat/Converter.vala
@@ -1,0 +1,28 @@
+//  /*
+//   *  Copyright (C) 2019 Felipe Escoto <felescoto95@hotmail.com>
+//   *
+//   *  This program or library is free software; you can redistribute it
+//   *  and/or modify it under the terms of the GNU Lesser General Public
+//   *  License as published by the Free Software Foundation; either
+//   *  version 3 of the License, or (at your option) any later version.
+//   *
+//   *  This library is distributed in the hope that it will be useful,
+//   *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//   *  Lesser General Public License for more details.
+//   *
+//   *  You should have received a copy of the GNU Lesser General
+//   *  Public License along with this library; if not, write to the
+//   *  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+//   *  Boston, MA 02110-1301 USA.
+//   */
+
+//  public class Spice.Services.Converter {
+
+//      public static void json_to_archive (File original_file) {
+//          var data = FileManager.get_data (original_file);
+
+//          var spice_up_file = new SpiceUpFile (original_file);
+//          spice_up_file.prepare ();
+//      }
+//  }

--- a/src/Services/FileFormat/SpiceUpFile.vala
+++ b/src/Services/FileFormat/SpiceUpFile.vala
@@ -54,8 +54,9 @@ public class Spice.Services.SpiceUpFile : Spice.Services.ZipArchiveHandler {
             clean ();
         } else {
             Services.FileManager.write_file (content_file, slide_manager.serialise ());
+            ImageHandler.delete_marked_images ();
             write_to_archive ();
-            // clean ();
+            clean ();
         }
     }
 

--- a/src/Services/FileFormat/SpiceUpFile.vala
+++ b/src/Services/FileFormat/SpiceUpFile.vala
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (C) 2019 Felipe Escoto <felescoto95@hotmail.com>
+ *
+ *  This program or library is free software; you can redistribute it
+ *  and/or modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General
+ *  Public License along with this library; if not, write to the
+ *  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA.
+ */
+
+public class Spice.Services.SpiceUpFile : Spice.Services.ZipArchiveHandler {
+    public File pictures_folder { get; private set; }
+    public File thumbnails_folder { get; private set; }
+
+    public File content_file { get; private set; }
+    public File styles_file { get; private set; }
+    public File version_file { get; private set; }
+
+    public unowned Spice.SlideManager slide_manager {get; private set; }
+
+    public SpiceUpFile (File _gzipped_file, Spice.SlideManager _slide_manager) {
+        base (_gzipped_file);
+
+        slide_manager = _slide_manager;
+    }
+
+    public void load_file () {
+        try {
+            open ();
+            string content = Services.FileManager.get_presentation_data (content_file);
+            slide_manager.load_data (content);
+        } catch (Error e) {
+            // GZipped file is probably the old format. T
+            // Try to use it as content_file as fallback
+            print ("Running opening as legacy mode\n");
+
+            string content = Services.FileManager.get_presentation_data (opened_file);
+            slide_manager.load_data (content);
+        }
+    }
+
+    public void save_file () {
+        if (slide_manager.slide_count () == 0) {
+            Services.FileManager.delete_file (opened_file);
+            clean ();
+        } else {
+            Services.FileManager.write_file (content_file, slide_manager.serialise ());
+            write_to_archive ();
+            // clean ();
+        }
+    }
+
+    public override void prepare () {
+        base.prepare ();
+
+        var base_path = unarchived_location.get_path ();
+        pictures_folder = File.new_for_path (Path.build_filename (base_path, "Pictures"));
+        thumbnails_folder = File.new_for_path (Path.build_filename (base_path, "Thumbnails"));
+
+        make_dir (pictures_folder);
+        make_dir (thumbnails_folder);
+
+        content_file = File.new_for_path (Path.build_filename (base_path, "content.json"));
+        styles_file = File.new_for_path (Path.build_filename (base_path, "styles.json"));
+        version_file = File.new_for_path (Path.build_filename (base_path, "version.json"));
+
+        make_file (content_file);
+        make_file (styles_file);
+        make_file (version_file);
+    }
+
+    public File get_random_file_name (File location, string format) {
+        do {
+            var path = Path.build_filename (location.get_path (), get_guid () + "." + format);
+
+            var file = File.new_for_path (path);
+            if (!file.query_exists ()) {
+                return file;
+            }
+        } while (true);
+    }
+
+    Rand rand = new Rand ();
+
+    private string get_guid () {
+        char GUID[40];
+        int t = 0;
+        string szTemp = "xxxxxxxx-xxxx-xx";
+        string szHex = "0123456789ABCDEFabcdef-";
+        int nLen = szTemp.length;
+
+        for (t = 0; t < nLen + 1; t++) {
+            var r = rand.next_int () % 22;
+            char c = ' ';
+
+            switch (szTemp[t]) {
+                case 'x' : { c = szHex [r]; } break;
+                case '-' : { c = '-'; } break;
+            }
+
+            GUID[t] = ( t < nLen ) ? c : 0x00;
+        }
+
+        return (string) GUID;
+    }
+}

--- a/src/Services/FileFormat/ZipArchiveHandler.vala
+++ b/src/Services/FileFormat/ZipArchiveHandler.vala
@@ -20,7 +20,7 @@
 public class Spice.Services.ZipArchiveHandler {
 
     // Prefix to be added at the beginning of the folder name when a gzipped file is opened. Should start with a period to hide the folder by default
-    private const string UNARCHIVED_PREFIX = ".~lock.spiceup.";
+    private const string UNARCHIVED_PREFIX = ".~lock.spice-up.";
 
     /**
      * The GZipped File that opened this archive

--- a/src/Services/FileFormat/ZipArchiveHandler.vala
+++ b/src/Services/FileFormat/ZipArchiveHandler.vala
@@ -123,6 +123,11 @@ public class Spice.Services.ZipArchiveHandler : GLib.Object {
         }
     }
 
+    public File get_file_from_basename (File location, string basename) {
+        var path = Path.build_filename (location.get_path (), basename);
+        return File.new_for_path (path);
+    }
+
     /**
      * Get's a random file inside the archive at the location specified
      * using a guid-like name.

--- a/src/Services/FileFormat/ZipArchiveHandler.vala
+++ b/src/Services/FileFormat/ZipArchiveHandler.vala
@@ -1,0 +1,245 @@
+/*
+ *  Copyright (C) 2019 Felipe Escoto <felescoto95@hotmail.com>
+ *
+ *  This program or library is free software; you can redistribute it
+ *  and/or modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 3 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General
+ *  Public License along with this library; if not, write to the
+ *  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301 USA.
+ */
+
+public class Spice.Services.ZipArchiveHandler {
+
+    // Prefix to be added at the beginning of the folder name when a gzipped file is opened. Should start with a period to hide the folder by default
+    private const string UNARCHIVED_PREFIX = ".~lock.spiceup.";
+
+    /**
+     * The GZipped File that opened this archive
+     */
+    public File opened_file { get; private set; }
+
+    /**
+     * The Unzipped folder location
+     */
+    public File unarchived_location { get; private set; }
+
+    /**
+     * Creates a zipped file for archive purposes
+     */
+    public ZipArchiveHandler (File gzipped_file) {
+        opened_file = gzipped_file.dup ();
+
+        var parent_folder = opened_file.get_parent ().get_path ();
+        unarchived_location = File.new_for_path (Path.build_filename (parent_folder, UNARCHIVED_PREFIX + opened_file.get_basename ()));
+    }
+
+    protected void make_dir (File file) {
+        if (!file.query_exists ()) {
+            file.make_directory_with_parents ();
+        }
+    }
+
+    protected void make_file (File file) {
+        if (!file.query_exists ()) {
+            file.create (FileCreateFlags.REPLACE_DESTINATION);
+        }
+    }
+
+    /**
+     * Used to create all the files needed for this if they do not exist.
+     *
+     * Should be overwritten to add your own files and folders for the internal
+     * file structure you require. Make sure to call base.prepare ()
+     */
+    public virtual void prepare () {
+        try {
+            var parent_folder = opened_file.get_parent ();
+            make_dir (parent_folder);
+            make_file (opened_file);
+            make_dir (unarchived_location);
+        } catch (Error e) {
+            error ("Could not write file: %s", e.message);
+        }
+    }
+
+    /**
+     * Used to check if the file was already extracted. Use this to handle recovery for your users.
+     */
+    public virtual bool is_opened () {
+        return unarchived_location.query_exists ();
+    }
+
+    /**
+     * Extracts the contents of the file to unarchived_location
+     */
+    public void open () throws Error {
+        extract (opened_file, unarchived_location);
+    }
+
+    /**
+     * Saves content from the unzipped location to the GZipped file.
+     */
+    public void write_to_archive () throws Error {
+        // Saving to a temp file first to avoid dataloss on a crash
+
+        var tmp_file = File.new_for_path (opened_file.get_path () + ".tmp");
+
+        compress (unarchived_location, tmp_file);
+        if (opened_file.query_exists ()) {
+            opened_file.delete ();
+        }
+
+        FileUtils.rename (tmp_file.get_path (), opened_file.get_path ());
+    }
+
+    /**
+     * Removes all files from the unarchived location. Should run before closing the program to cleanup temp files
+     */
+    public void clean () throws Error {
+        // Checking if it contains the prefix as a safety to prevent errors
+        // This function is dangerous. not using the constant here to prevent erors
+        if (is_opened () && unarchived_location.get_path ().contains (".~lock.spice-up.")) {
+            delete_recursive (unarchived_location);
+            unarchived_location.delete ();
+        }
+    }
+
+    // DANGEROUS
+    private void delete_recursive (File file) {
+        try {
+            var enumerator = file.enumerate_children (FileAttribute.STANDARD_NAME, 0);
+
+            FileInfo file_info;
+            while ((file_info = enumerator.next_file ()) != null) {
+                var current_file = file.resolve_relative_path (file_info.get_name ());
+
+                if (file_info.get_file_type () == FileType.DIRECTORY) {
+                    delete_recursive (current_file);
+                }
+
+                current_file.delete ();
+            }
+        } catch (Error e) {
+            critical ("Error: %s\n", e.message);
+        }
+    }
+
+    // Extracts all contents of the gzip file to the location
+    private static void extract (File gzipped_file, File location) throws Error {
+        Archive.ExtractFlags flags;
+        flags = Archive.ExtractFlags.TIME;
+        flags |= Archive.ExtractFlags.PERM;
+        flags |= Archive.ExtractFlags.ACL;
+        flags |= Archive.ExtractFlags.FFLAGS;
+
+        Archive.Read archive = new Archive.Read ();
+        archive.support_format_all ();
+        archive.support_filter_all ();
+
+        Archive.WriteDisk extractor = new Archive.WriteDisk ();
+        extractor.set_options (flags);
+        extractor.set_standard_lookup ();
+
+        if (archive.open_filename (gzipped_file.get_path (), 10240) != Archive.Result.OK) {
+            throw new FileError.FAILED ("Error opening %s: %s (%d)", gzipped_file.get_path (), archive.error_string (), archive.errno ());
+            return;
+        }
+
+        unowned Archive.Entry entry;
+        Archive.Result last_result;
+        while ((last_result = archive.next_header (out entry)) == Archive.Result.OK) {
+            entry.set_pathname (Path.build_filename (location.get_path (), entry.pathname ()));
+
+            if (extractor.write_header (entry) != Archive.Result.OK) {
+                continue;
+            }
+
+            void* buffer = null;
+            size_t buffer_length;
+            Posix.off_t offset;
+            while (archive.read_data_block (out buffer, out buffer_length, out offset) == Archive.Result.OK) {
+                if (extractor.write_data_block (buffer, buffer_length, offset) != Archive.Result.OK) {
+                    break;
+                }
+            }
+        }
+
+        if (last_result != Archive.Result.EOF) {
+            critical ("Error: %s (%d)", archive.error_string (), archive.errno ());
+        }
+    }
+
+    // Compresses all files recursibly from location to the gzipped file.
+    private static void compress (File location, File gzipped_file) throws Error {
+        var to_write = File.new_for_path (gzipped_file.get_path ());
+        if (to_write.query_exists ()) {
+            to_write.delete ();
+        }
+
+        to_write.create (FileCreateFlags.REPLACE_DESTINATION);
+
+        Archive.Write archive = new Archive.Write ();
+        archive.set_format_zip ();
+        archive.open_filename (to_write.get_path ());
+
+        add_to_archive_recursive (location, location, archive);
+
+        if (archive.close () != Archive.Result.OK) {
+            critical ("Error : %s (%d)", archive.error_string (), archive.errno ());
+        }
+    }
+
+    private static void add_to_archive_recursive (File initial_folder, File folder, Archive.Write archive) {
+        try {
+            var enumerator = folder.enumerate_children (FileAttribute.STANDARD_NAME, 0);
+
+            FileInfo current_info;
+            while ((current_info = enumerator.next_file ()) != null) {
+                var current_file = folder.resolve_relative_path (current_info.get_name ());
+
+                if (current_info.get_file_type () == FileType.DIRECTORY) {
+                    add_to_archive_recursive (initial_folder, current_file, archive);
+                } else {
+                    GLib.FileInfo file_info = current_file.query_info (GLib.FileAttribute.STANDARD_SIZE, GLib.FileQueryInfoFlags.NONE);
+
+                    FileInputStream input_stream = current_file.read ();
+                    DataInputStream data_input_stream = new DataInputStream (input_stream);
+
+                    // Add an entry to the archive
+                    Archive.Entry entry = new Archive.Entry ();
+                    entry.set_pathname (initial_folder.get_relative_path (current_file));
+                    entry.set_size (file_info.get_size ());
+                    entry.set_filetype ((uint) Posix.S_IFREG);
+                    entry.set_perm (0644);
+
+                    if (archive.write_header (entry) != Archive.Result.OK) {
+                        critical ("Error writing '%s': %s (%d)", current_file.get_path (), archive.error_string (), archive.errno ());
+                        return;
+                    }
+
+                    // Add the actual content of the file
+                    size_t bytes_read;
+                    uint8[64] buffer = new uint8[64];
+                    while (data_input_stream.read_all (buffer, out bytes_read)) {
+                        if (bytes_read <= 0) {
+                            break;
+                        }
+
+                        archive.write_data (buffer, bytes_read);
+                    }
+                }
+            }
+        } catch (Error e) {
+            critical ("Error: %s\n", e.message);
+        }
+    }
+}

--- a/src/Services/FileManager.vala
+++ b/src/Services/FileManager.vala
@@ -150,10 +150,10 @@ public class Spice.Services.FileManager {
         }
     }
 
-    public static string open_file (File file) {
-        settings.add_file (file.get_path ());
-        return get_presentation_data (file);
-    }
+    //  private static string open_file (File file) {
+    //
+    //      return get_presentation_data (file);
+    //  }
 
     public static void delete_file (File file) {
         if (file != null

--- a/src/Services/ImageHandler.vala
+++ b/src/Services/ImageHandler.vala
@@ -43,7 +43,7 @@ public class Spice.ImageHandler : Object {
         }
     }
 
-    private File current_image_file {
+    public File current_image_file {
         owned get {
             return File.new_for_path (url);
         } set {
@@ -144,15 +144,15 @@ public class Spice.ImageHandler : Object {
         Spice.Services.FileManager.base64_to_file (file.get_path (), data);
     }
 
-    public static void add_for_deletion (ImageHandler image) {
+    private static void add_for_deletion (ImageHandler image) {
         for_deletion.set (image.current_image_file.get_basename (), image.current_image_file);
     }
 
-    public static void remove_from_deletion (ImageHandler image) {
+    private static void remove_from_deletion (ImageHandler image) {
         for_deletion.unset (image.current_image_file.get_basename ());
     }
 
-    public static void delete_marked_images () {
+    private static void delete_marked_images () {
         foreach (var image in for_deletion.values) {
             image.delete ();
         };

--- a/src/Services/ImageHandler.vala
+++ b/src/Services/ImageHandler.vala
@@ -22,8 +22,6 @@
 public class Spice.ImageHandler : Object {
     public signal void file_changed ();
 
-    private static Gee.HashMap<string, File> for_deletion = new Gee.HashMap<string, File> ();
-
     private unowned Services.SpiceUpFile spice_file;
     private FileMonitor? monitor = null;
     private bool file_changing = false;
@@ -50,7 +48,7 @@ public class Spice.ImageHandler : Object {
             monitor_file (value);
             valid = (value.query_exists () && Utils.is_valid_image (value));
             url_ = value.get_path ();
-            print (url);
+            print (url + "\n");
             file_changed ();
         }
     }
@@ -84,6 +82,8 @@ public class Spice.ImageHandler : Object {
 
     public void copy_to_another_file () {
         var file = spice_file.get_random_file_name (spice_file.pictures_folder, image_extension);
+
+        spice_file.file_collector.unref_file (current_image_file);
 
         current_image_file.copy (file, FileCopyFlags.NONE);
         current_image_file = file;
@@ -142,21 +142,5 @@ public class Spice.ImageHandler : Object {
 
     private void data_to_file (string data, File file) {
         Spice.Services.FileManager.base64_to_file (file.get_path (), data);
-    }
-
-    private static void add_for_deletion (ImageHandler image) {
-        for_deletion.set (image.current_image_file.get_basename (), image.current_image_file);
-    }
-
-    private static void remove_from_deletion (ImageHandler image) {
-        for_deletion.unset (image.current_image_file.get_basename ());
-    }
-
-    private static void delete_marked_images () {
-        foreach (var image in for_deletion.values) {
-            image.delete ();
-        };
-
-        for_deletion = new Gee.HashMap<string, File> ();
     }
 }

--- a/src/Services/ImageHandler.vala
+++ b/src/Services/ImageHandler.vala
@@ -20,11 +20,7 @@
 */
 
 public class Spice.ImageHandler : Object {
-    public static uint FILE_ID = 0;
-
     public signal void file_changed ();
-
-    private uint file_id;
 
     const string FILENAME = "/spice-up-%s-img-%u.%s";
 
@@ -32,47 +28,77 @@ public class Spice.ImageHandler : Object {
     private bool file_changing = false;
 
     public bool valid = false;
-    private string? base64_image = null;
 
-    public string image_extension { get; private set; }
+    public string image_extension {
+        owned get {
+            return get_extension (url);
+        }
+    }
 
     private string url_ = "";
     public string url {
         get {
-            return url_;
+            return  url_;
+        }
+    }
+
+    private File current_image_file {
+        owned get {
+            return File.new_for_path (url);
         } set {
-            url_ = value;
-            var file = File.new_for_path (value);
-            monitor_file (file);
-            valid = (file.query_exists () && Utils.is_valid_image (file));
+            monitor_file (value);
+            valid = (value.query_exists () && Utils.is_valid_image (value));
+            url_ = value.get_path ();
+            print (url);
             file_changed ();
         }
     }
 
-    public ImageHandler.from_data (string _extension, string _base64_data) {
-        file_id = FILE_ID++;
-        image_extension = _extension != "" ? _extension : "png";
-        base64_image = _base64_data;
-        url = data_to_file (_base64_data);
+    private unowned Services.SpiceUpFile spice_file;
+
+    public ImageHandler.from_data (Services.SpiceUpFile _spice_file, string _extension, string _base64_data) {
+        print ("From data\n");
+        spice_file = _spice_file;
+
+        var file = spice_file.get_random_file_name (spice_file.pictures_folder, _extension);
+        data_to_file (_base64_data, file);
+
+        current_image_file = file;
     }
 
-    public ImageHandler.from_file (File file) {
-        file_id = FILE_ID++;
-        replace (file);
+    public ImageHandler.from_archived_file (Services.SpiceUpFile _spice_file, string filename) {
+        print ("From archive\n");
+        spice_file = _spice_file;
+
+        var path = Path.build_filename (spice_file.pictures_folder.get_path (), filename);
+        current_image_file = File.new_for_path (path);
+    }
+
+    public ImageHandler.from_file (Services.SpiceUpFile _spice_file, File _file) {
+        print ("From file\n");
+        spice_file = _spice_file;
+
+        var file = spice_file.get_random_file_name (spice_file.pictures_folder, get_extension (_file.get_basename ()));
+        replace (_file);
+
+        current_image_file = file;
     }
 
     public void replace (File file) {
+        // TODO: Implement copy from outside file to this
         if (monitor != null) {
             monitor.cancel ();
         }
 
-        image_extension = get_extension (file.get_basename ());
-        data_from_file (file);
-        url = data_to_file (base64_image);
+        //  image_extension = get_extension (file.get_basename ());
+        //  data_from_file (file);
+        //  url = data_to_file (base64_image);
     }
 
     public string serialize () {
-        return """"image":"%s", "image-data":"%s" """.printf (image_extension, base64_image);
+        var file = File.new_for_path (url);
+
+        return """"archived-image":"%s" """.printf (file.get_basename ());
     }
 
     private void monitor_file (File file) {
@@ -83,7 +109,6 @@ public class Spice.ImageHandler : Object {
                 if (event == FileMonitorEvent.CHANGED) {
                     file_changing = true;
                 } else if (event == FileMonitorEvent.CHANGES_DONE_HINT && file_changing) {
-                    data_from_file (file);
                     file_changed ();
                     file_changing = false;
                 }
@@ -102,14 +127,7 @@ public class Spice.ImageHandler : Object {
         }
     }
 
-    private void data_from_file (File file) {
-        base64_image = Spice.Services.FileManager.file_to_base64 (file);
-    }
-
-    private string data_to_file (string data) {
-        var filename = Environment.get_tmp_dir () + FILENAME.printf (Environment.get_user_name (), file_id, image_extension);
-        Spice.Services.FileManager.base64_to_file (filename, data);
-
-        return filename;
+    private void data_to_file (string data, File file) {
+        Spice.Services.FileManager.base64_to_file (file.get_path (), data);
     }
 }

--- a/src/Services/ImageHandler.vala
+++ b/src/Services/ImageHandler.vala
@@ -66,11 +66,13 @@ public class Spice.ImageHandler : Object {
         current_image_file = file;
     }
 
-    public ImageHandler.from_archived_file (Services.SpiceUpFile _spice_file, string filename) {
+    public ImageHandler.from_archived_file (Services.SpiceUpFile? _spice_file, string filename) {
         print ("From archive\n");
         spice_file = _spice_file;
 
-        var path = Path.build_filename (spice_file.pictures_folder.get_path (), filename);
+        var pictures_folder = spice_file != null ? spice_file.pictures_folder.get_path () : "";
+        var path = Path.build_filename (pictures_folder, filename);
+
         current_image_file = File.new_for_path (path);
     }
 
@@ -84,11 +86,16 @@ public class Spice.ImageHandler : Object {
         current_image_file = file;
     }
 
+    public void copy_to_another_file () {
+        var file = spice_file.get_random_file_name (spice_file.pictures_folder, image_extension);
+
+        current_image_file.copy (file, FileCopyFlags.NONE);
+        current_image_file = file;
+    }
+
     public void replace (File file) {
         // TODO: Implement copy from outside file to this
-        if (monitor != null) {
-            monitor.cancel ();
-        }
+
 
         //  image_extension = get_extension (file.get_basename ());
         //  data_from_file (file);
@@ -103,6 +110,10 @@ public class Spice.ImageHandler : Object {
 
     private void monitor_file (File file) {
         try {
+            if (monitor != null) {
+                monitor.cancel ();
+            }
+
             monitor = file.monitor (FileMonitorFlags.NONE, null);
 
             monitor.changed.connect ((src, dest, event) => {

--- a/src/Services/Slide.vala
+++ b/src/Services/Slide.vala
@@ -27,6 +27,7 @@ public class Spice.Slide : Object {
     public Canvas canvas;
     public Gtk.Image preview;
 
+    private File? thumbnail_file = null;
     public string preview_data { get; private set; default = ""; }
     public string notes { get; set; default = ""; }
     public Gtk.StackTransitionType transition { get; set; default = Gtk.StackTransitionType.NONE; }
@@ -46,8 +47,11 @@ public class Spice.Slide : Object {
                     item.visible = true;
                 }
 
+                canvas.window.current_file.file_collector.ref_file (thumbnail_file);
                 to_be_deleted.clear ();
             } else {
+                canvas.window.current_file.file_collector.unref_file (thumbnail_file);
+
                 foreach (var widget in canvas.get_children ()) {
                     if (widget is CanvasItem && widget.visible) {
                         CanvasItem item = (CanvasItem) widget;
@@ -103,11 +107,33 @@ public class Spice.Slide : Object {
     private void load_data () {
         if (save_data == null) return;
 
-        preview_data = save_data.get_string_member ("preview");
-        if (preview_data != null && preview_data != "") {
-            var pixbuf = Utils.base64_to_pixbuf (preview_data);
+        if (save_data.has_member ("preview")) {
+            preview_data = save_data.get_string_member ("preview");
 
-            preview.set_from_pixbuf (pixbuf.scale_simple (SlideList.WIDTH, SlideList.HEIGHT, Gdk.InterpType.BILINEAR));
+            if (preview_data != null && preview_data != "") {
+                var pixbuf = Utils.base64_to_pixbuf (preview_data);
+
+                preview.set_from_pixbuf (pixbuf.scale_simple (SlideList.WIDTH, SlideList.HEIGHT, Gdk.InterpType.BILINEAR));
+            }
+        } else if (save_data.has_member ("thumbnail")) {
+            print ("Loading thumbnail file...\n");
+            var thumbnail_basename = save_data.get_string_member ("thumbnail");
+            if (canvas != null && thumbnail_basename != "") {
+                var current_file = canvas.window.current_file;
+                thumbnail_file = current_file.get_file_from_basename (current_file.thumbnails_folder, thumbnail_basename);
+
+                var pixbuf = new Gdk.Pixbuf.from_file (thumbnail_file.get_path ());
+                preview.set_from_pixbuf (pixbuf);
+            }
+        }
+
+        if (thumbnail_file == null && canvas != null) {
+            var current_file = canvas.window.current_file;
+            thumbnail_file = current_file.get_random_file_name (current_file.thumbnails_folder, "jpg");
+        }
+
+        if (canvas != null) {
+            canvas.window.current_file.file_collector.ref_file (thumbnail_file);
         }
 
         if (save_data.has_member ("transition")) {
@@ -143,7 +169,7 @@ public class Spice.Slide : Object {
         });
     }
 
-    public string serialise () {
+    public string serialise (bool save_preview = false) {
         if (this.save_data != null) {
             var root = new Json.Node (Json.NodeType.OBJECT);
             root.set_object (save_data);
@@ -164,8 +190,19 @@ public class Spice.Slide : Object {
             }
         }
 
+        if (save_preview && thumbnail_file != null) {
+            print ("Saving thumbnail at %s\n", thumbnail_file.get_path ());
+            try {
+                preview.pixbuf.save (thumbnail_file.get_path (), "jpeg");
+            } catch (Error e) {
+                warning (e.message);
+            }
+        }
+
+        string preview_name = save_preview && thumbnail_file != null ? thumbnail_file.get_basename () : "";
         var raw_notes = (string) GLib.Base64.encode (notes.data);
-        return "{%s, \"transition\": %d, \"items\": [%s], \"notes\": \"%s\", \"preview\": \"%s\"}\n".printf (canvas.serialise (), (int) transition, data, raw_notes, preview_data);
+
+        return "{%s, \"transition\": %d, \"items\": [%s], \"notes\": \"%s\", \"thumbnail\": \"%s\" }\n".printf (canvas.serialise (), (int) transition, data, raw_notes, preview_name);
     }
 
     public void delete () {

--- a/src/Services/Slide.vala
+++ b/src/Services/Slide.vala
@@ -31,6 +31,7 @@ public class Spice.Slide : Object {
     public string notes { get; set; default = ""; }
     public Gtk.StackTransitionType transition { get; set; default = Gtk.StackTransitionType.NONE; }
 
+    private Gee.LinkedList<Spice.CanvasItem> to_be_deleted = new Gee.LinkedList<Spice.CanvasItem>();
     private bool visible_ = true;
     public bool visible {
         get {
@@ -39,6 +40,22 @@ public class Spice.Slide : Object {
             this.visible_ = value;
             canvas.visible = value;
             visible_changed (value);
+
+            if (value) {
+                foreach (var item in to_be_deleted) {
+                    item.visible = true;
+                }
+
+                to_be_deleted.clear ();
+            } else {
+                foreach (var widget in canvas.get_children ()) {
+                    if (widget is CanvasItem && widget.visible) {
+                        CanvasItem item = (CanvasItem) widget;
+                        item.visible = false;
+                        to_be_deleted.add (item);
+                    }
+                }
+            }
         }
     }
 

--- a/src/Services/SlideManager.vala
+++ b/src/Services/SlideManager.vala
@@ -150,7 +150,7 @@ public class Spice.SlideManager : Object {
 
         foreach (var slide in slides) {
             if (slide.visible) {
-                data = data + (data != "" ? "," + slide.serialise () : slide.serialise ());
+                data = data + (data != "" ? "," + slide.serialise (true) : slide.serialise (true));
             }
         }
 

--- a/src/Services/SlideManager.vala
+++ b/src/Services/SlideManager.vala
@@ -129,7 +129,6 @@ public class Spice.SlideManager : Object {
         }
 
         slides.clear ();
-        ImageHandler.FILE_ID = 0;
 
         reseted ();
     }

--- a/src/Services/Utils.vala
+++ b/src/Services/Utils.vala
@@ -158,9 +158,13 @@ public class Spice.Utils {
     }
 
     public static Spice.CanvasItem? canvas_item_from_data (Json.Object data, Spice.Canvas? canvas) {
-        string type = data.get_string_member ("type");
-        CanvasItem? item = null;
+        string type = "";
 
+        if (data.has_member ("type")) {
+            type = data.get_string_member ("type");
+        }
+
+        CanvasItem? item = null;
         switch (type) {
             case "text":
                 item = new TextItem (canvas, data);

--- a/src/Tests/CMakeLists.txt
+++ b/src/Tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory (Canvas)
 add_subdirectory (ColorButton)
 add_subdirectory (ColorItem)
-add_subdirectory (ImageItem)
+# add_subdirectory (ImageItem)
 add_subdirectory (TextItem)

--- a/src/Widgets/CanvasItems/ImageItem.vala
+++ b/src/Widgets/CanvasItems/ImageItem.vala
@@ -40,7 +40,7 @@ public class Spice.ImageItem : Spice.CanvasItem {
         }""";
 
     public string extension {
-        get {
+        owned get {
             return image.image_extension;
         }
     }
@@ -62,7 +62,7 @@ public class Spice.ImageItem : Spice.CanvasItem {
     public ImageItem.from_file (Canvas? _canvas, File file) {
         Object (canvas: _canvas, save_data: null);
 
-        this.image = new ImageHandler.from_file (file);
+        this.image = new ImageHandler.from_file (canvas.window.current_file, file);
         connect_image ();
 
         if (canvas != null) style ();
@@ -71,7 +71,7 @@ public class Spice.ImageItem : Spice.CanvasItem {
     public ImageItem.from_data (Canvas? _canvas, string base64_image, string extension) {
         Object (canvas: _canvas, save_data: null);
 
-        this.image = new ImageHandler.from_data (extension, base64_image);
+        this.image = new ImageHandler.from_data (canvas.window.current_file, extension, base64_image);
         connect_image ();
 
         if (canvas != null) style ();
@@ -86,10 +86,13 @@ public class Spice.ImageItem : Spice.CanvasItem {
 
         if (base64_image != null && base64_image != "") {
             var extension = save_data.get_string_member ("image");
-            image = new ImageHandler.from_data (extension, base64_image);
+            image = new ImageHandler.from_data (canvas.window.current_file, extension, base64_image);
+        } else if (save_data.has_member ("archived-image")) {
+            // CURRENT Method of loading
+            image = new ImageHandler.from_archived_file (canvas.window.current_file, save_data.get_string_member ("archived-image"));
         } else {
             var tmp_uri = save_data.get_string_member ("image");
-            image = new ImageHandler.from_file (File.new_for_uri (tmp_uri));
+            image = new ImageHandler.from_file (canvas.window.current_file, File.new_for_uri (tmp_uri));
         }
 
         connect_image ();

--- a/src/Widgets/CanvasItems/ImageItem.vala
+++ b/src/Widgets/CanvasItems/ImageItem.vala
@@ -77,18 +77,6 @@ public class Spice.ImageItem : Spice.CanvasItem {
         if (canvas != null) style ();
     }
 
-    construct {
-        notify["visible"].connect (() => {
-            if (this.visible) {
-                print ("Removing from deletion\n");
-                ImageHandler.remove_from_deletion (image);
-            } else {
-                print ("adding for deletion\n");
-                ImageHandler.add_for_deletion (image);
-            }
-        });
-    }
-
     protected override void load_item_data () {
         string? base64_image = null;
 
@@ -130,6 +118,14 @@ public class Spice.ImageItem : Spice.CanvasItem {
         image.file_changed.connect (() => {
              unstyle ();
              style ();
+        });
+
+        notify["visible"].connect (() => {
+            if (this.visible) {
+                canvas.window.current_file.unmark_for_deletion (image.current_image_file);
+            } else {
+                canvas.window.current_file.mark_for_deletion (image.current_image_file);
+            }
         });
     }
 }

--- a/src/Widgets/CanvasItems/ImageItem.vala
+++ b/src/Widgets/CanvasItems/ImageItem.vala
@@ -77,6 +77,18 @@ public class Spice.ImageItem : Spice.CanvasItem {
         if (canvas != null) style ();
     }
 
+    construct {
+        notify["visible"].connect (() => {
+            if (this.visible) {
+                print ("Removing from deletion\n");
+                ImageHandler.remove_from_deletion (image);
+            } else {
+                print ("adding for deletion\n");
+                ImageHandler.add_for_deletion (image);
+            }
+        });
+    }
+
     protected override void load_item_data () {
         string? base64_image = null;
 

--- a/src/Widgets/CanvasItems/ImageItem.vala
+++ b/src/Widgets/CanvasItems/ImageItem.vala
@@ -120,11 +120,15 @@ public class Spice.ImageItem : Spice.CanvasItem {
              style ();
         });
 
+        if (canvas != null) {
+            canvas.window.current_file.file_collector.ref_file (image.current_image_file);
+        }
+
         notify["visible"].connect (() => {
             if (this.visible) {
-                canvas.window.current_file.unmark_for_deletion (image.current_image_file);
+                canvas.window.current_file.file_collector.ref_file (image.current_image_file);
             } else {
-                canvas.window.current_file.mark_for_deletion (image.current_image_file);
+                canvas.window.current_file.file_collector.unref_file (image.current_image_file);
             }
         });
     }

--- a/src/Widgets/CanvasItems/ImageItem.vala
+++ b/src/Widgets/CanvasItems/ImageItem.vala
@@ -89,7 +89,7 @@ public class Spice.ImageItem : Spice.CanvasItem {
             image = new ImageHandler.from_data (canvas.window.current_file, extension, base64_image);
         } else if (save_data.has_member ("archived-image")) {
             // CURRENT Method of loading
-            image = new ImageHandler.from_archived_file (canvas.window.current_file, save_data.get_string_member ("archived-image"));
+            image = new ImageHandler.from_archived_file (canvas != null ? canvas.window.current_file : null, save_data.get_string_member ("archived-image"));
         } else {
             var tmp_uri = save_data.get_string_member ("image");
             image = new ImageHandler.from_file (canvas.window.current_file, File.new_for_uri (tmp_uri));

--- a/src/Widgets/Toolbars/ImageBar.vala
+++ b/src/Widgets/Toolbars/ImageBar.vala
@@ -22,6 +22,7 @@
 public class Spice.Widgets.ImageToolbar : Spice.Widgets.Toolbar {
     private Gtk.MenuButton open_with;
     private Gtk.Button replace_image;
+    private Gtk.Button unlink_image;
 
     private unowned SlideManager manager;
 
@@ -42,6 +43,22 @@ public class Spice.Widgets.ImageToolbar : Spice.Widgets.Toolbar {
         replace_image.get_style_context ().add_class ("spice");
         replace_image.get_style_context ().add_class ("image-button");
 
+        // FIXME: Add unlink button
+        unlink_image = new Gtk.Button ();
+        unlink_image.add (new Gtk.Image.from_icon_name ("text-html-symbolic", Gtk.IconSize.MENU));
+        unlink_image.set_tooltip_markup (_("Unlink shared file"));
+        unlink_image.get_style_context ().add_class ("spice");
+        unlink_image.get_style_context ().add_class ("image-button");
+
+        unlink_image.clicked.connect (() => {
+            var item = item as Spice.ImageItem;
+
+            if (item != null) {
+                item.image.copy_to_another_file ();
+                unlink_image.sensitive = false;
+            }
+        });
+
         replace_image.clicked.connect (() => {
             var file = Spice.Services.FileManager.open_image ();
 
@@ -53,6 +70,7 @@ public class Spice.Widgets.ImageToolbar : Spice.Widgets.Toolbar {
 
         add (open_with);
         add (replace_image);
+        add (unlink_image);
     }
 
     private void launch_editor (AppInfo app) {
@@ -94,6 +112,8 @@ public class Spice.Widgets.ImageToolbar : Spice.Widgets.Toolbar {
                 warning ("Could not get file info %s", e.message);
                 return;
             }
+
+            unlink_image.sensitive = manager.window.current_file.file_collector.file_references (item.image.current_image_file) > 1;
         }
     }
 


### PR DESCRIPTION
While using JSONs as a file format is good, it has a lot of limitations such as always having to open completely the file in order to view it's contents, as well as images being almost 30% larger due to having to make them into base64. Being able to store files as a Zipped file brings support to a lot of things, most importantly being able to include a "git repo" inside every presentation to store multiple versions of said files. 

## Proposed Folder Structure:

- `content.json` The json with the slideshow data
- `styles.json` Json with text styles, and other type of data
- `index.html` The HTML file with the JS to keep html rendering support
- `version` File which holds the current version of the file. For future proofing 
- `thumbnail` Just a link to the thumbnail file at `/Thumbnails`
- `/Pictures/` For images. 
- `/Thumbnails/` To store the slide thumbnails
- `/Videos` To store videos (Future feature)
- `/Shapes` To store SVG shapes (Future future)
- `/.git/` The place for the git repo. (Future feature)

Pictures, Thumnails and others are stored with randomized file names to prevent collisions, and could be re-used in multiple places while only storing one file

## TODO: 

- [x] Move images from content file to `/Pictures`
- [x] Move thumbnails from content file to `/Thumbnails`
- [ ] Fetch file thumbnail from content file, and store it as cache
    - To prevent reading from multiple mb of files just to render the initial images 
- [x] Make a SpiceUpFile the central place to manage all files and images
    - This should handle object creation and deletion when slides and canvas items are hidden
- [ ] Re-add Image tests
- [ ] Update debian control file for new libarchive dependency
- [x] Duplicated images will now use the same file. Can be "Unlinked" though the image toolbar

Fixes #220 