### PR TITLE
CSS: Use raised class instead of custom CSS

### DIFF
--- a/data/stylesheet.css
+++ b/data/stylesheet.css
@@ -80,67 +80,18 @@ GtkTextView:selected, textview:selected {
      background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.3));
 }
 
-GtkToggleButton.spice, .spice,
-.spice-dynamic-toolbar .spice {
-    color: #DEDEDE;
-    background-color: rgba(255,255,255,0.05);
+GtkToggleButton.raised,
+.raised,
+.spice-dynamic-toolbar .raised {
     padding: 2px 8px;
-    border-radius: 4px;
-    border-width: 1px;
-    box-shadow: 0px 0px 1px 1px rgba (0,0,0, 0.1);
 }
 
-.spice-dynamic-toolbar .spice .entry {
-    padding: 0px 3px;
+.spice-dynamic-toolbar .raised .entry {
+    padding: 0 3px;
 }
 
-.spice-dynamic-toolbar .spice.padding-none {
-    padding: 0px;
-}
-
-.spice:active,
-.spice:checked,
-.spice:selected {
-    background: none;
-    background-color: alpha (#000, 0.05);
-
-    border-color: alpha (#000, 0.27);
-    box-shadow:
-        inset 0 0 0 1px alpha (#000, 0.05),
-        0 1px 0 0 alpha (@bg_highlight_color, 0.3);
-}
-
-.spice.suggested-action:active,
-.spice.suggested-action:selected {
-    background: shade (@selected_bg_color, 0.8);
-    border-color: shade (@selected_bg_color, 0.8);
-}
-
-.spice:disabled, .spice:disabled image {
-    background-image: none;
-    background-color: transparent;
-    color: @insensitive_color;
-}
-
-.linked .spice {
-    border-left-width: 0;
-    border-radius: 0;
-}
-
-.linked .spice:first-child {
-    border-width: 1px;
-    border-bottom-right-radius: 0;
-    border-top-right-radius: 0;
-    border-bottom-left-radius: 4px;
-    border-top-left-radius: 4px;
-}
-
-.linked .spice:last-child {
-    border-left-width: 0;
-    border-bottom-right-radius: 4px;
-    border-top-right-radius: 4px;
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
+.spice-dynamic-toolbar .raised.padding-none {
+    padding: 0;
 }
 
 .spice-scale {

--- a/src/Widgets/Headerbar.vala
+++ b/src/Widgets/Headerbar.vala
@@ -119,7 +119,7 @@ public class Spice.Headerbar : Gtk.HeaderBar {
         Gtk.Image show_notes_image = new Gtk.Image.from_icon_name ("accessories-text-editor-symbolic", Gtk.IconSize.BUTTON);
         show_notes_image.margin = 3;
 
-        show_notes.get_style_context ().add_class ("spice");
+        show_notes.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
         show_notes.tooltip_markup = Utils.get_accel_tooltip (Window.ACTION_NOTES, _("Presenter Notes"));
         show_notes.add (show_notes_image);
 
@@ -187,7 +187,7 @@ public class Spice.Headerbar : Gtk.HeaderBar {
             Gtk.Image image = new Gtk.Image.from_icon_name (icon_name, Gtk.IconSize.BUTTON);
             image.margin = 3;
 
-            get_style_context ().add_class ("spice");
+            get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
             set_tooltip_markup (description);
             this.add (image);
         }

--- a/src/Widgets/Toolbars/CommonBar.vala
+++ b/src/Widgets/Toolbars/CommonBar.vala
@@ -36,12 +36,12 @@ public class Spice.Widgets.CommonToolbar : Spice.Widgets.Toolbar {
 
         delete_button = new Gtk.Button.from_icon_name ("edit-delete-symbolic", Gtk.IconSize.MENU);
         delete_button.set_tooltip_markup (Utils.get_accel_tooltip (Window.ACTION_DELETE, _("Delete")));
-        delete_button.get_style_context ().add_class ("spice");
+        delete_button.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
 
         delete_button.clicked.connect (manager.window.delete_object);
 
         clone_button = new Gtk.Button.from_icon_name ("edit-copy-symbolic", Gtk.IconSize.MENU);
-        clone_button.get_style_context ().add_class ("spice");
+        clone_button.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
         clone_button.set_tooltip_markup (Utils.get_accel_tooltip (Window.ACTION_CLONE, _("Clone")));
 
         clone_button.clicked.connect (() => {
@@ -53,11 +53,11 @@ public class Spice.Widgets.CommonToolbar : Spice.Widgets.Toolbar {
         });
 
         to_top = new Gtk.Button.from_icon_name ("selection-raise-symbolic", Gtk.IconSize.MENU);
-        to_top.get_style_context ().add_class ("spice");
+        to_top.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
         to_top.set_tooltip_markup (Utils.get_accel_tooltip (Window.ACTION_BRING_FWD, _("Bring forward")));
 
         to_bottom = new Gtk.Button.from_icon_name ("selection-lower-symbolic", Gtk.IconSize.MENU);
-        to_bottom.get_style_context ().add_class ("spice");
+        to_bottom.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
         to_bottom.set_tooltip_markup (Utils.get_accel_tooltip (Window.ACTION_BRING_BWD, _("Send backward")));
 
         var position_grid = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0);

--- a/src/Widgets/Toolbars/ImageBar.vala
+++ b/src/Widgets/Toolbars/ImageBar.vala
@@ -33,13 +33,13 @@ public class Spice.Widgets.ImageToolbar : Spice.Widgets.Toolbar {
         open_with = new Gtk.MenuButton ();
         open_with.add (new Gtk.Image.from_icon_name ("applications-graphics-symbolic", Gtk.IconSize.MENU));
         open_with.set_tooltip_text (_("Edit image with…"));
-        open_with.get_style_context ().add_class ("spice");
+        open_with.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
         open_with.get_style_context ().add_class ("image-button");
 
         replace_image = new Gtk.Button ();
         replace_image.add (new Gtk.Image.from_icon_name ("document-new-symbolic", Gtk.IconSize.MENU));
         replace_image.set_tooltip_text (_("Replace Image…"));
-        replace_image.get_style_context ().add_class ("spice");
+        replace_image.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
         replace_image.get_style_context ().add_class ("image-button");
 
         replace_image.clicked.connect (() => {

--- a/src/Widgets/Toolbars/ShapeBar.vala
+++ b/src/Widgets/Toolbars/ShapeBar.vala
@@ -39,7 +39,7 @@ public class Spice.Widgets.ShapeToolbar : Spice.Widgets.Toolbar {
         border_radius.margin = 12;
 
         var border_radius_button = new Gtk.Button.from_icon_name ("applications-engineering-symbolic", Gtk.IconSize.MENU);
-        border_radius_button.get_style_context ().add_class ("spice");
+        border_radius_button.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
         border_radius_button.set_tooltip_text (_("Roundness"));
 
         var border_radius_popover = new Gtk.Popover (border_radius_button);

--- a/src/Widgets/Toolbars/TextBar.vala
+++ b/src/Widgets/Toolbars/TextBar.vala
@@ -87,7 +87,7 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
         align_button_image = new Gtk.Image.from_icon_name ("format-justify-fill-symbolic", Gtk.IconSize.MENU);
 
         var align_button = new Gtk.Button ();
-        align_button.get_style_context ().add_class ("spice");
+        align_button.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
         align_button.set_tooltip_text (_("Align"));
         align_button.add (align_button_image);
 
@@ -116,7 +116,7 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
         justification.append_icon ("format-justify-fill-symbolic", Gtk.IconSize.MENU);
 
         foreach (var child in justification.get_children ()) {
-            child.get_style_context ().add_class ("spice");
+            child.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
         }
 
         align = new Granite.Widgets.ModeButton ();
@@ -130,7 +130,7 @@ public class Spice.Widgets.TextToolbar : Spice.Widgets.Toolbar {
         align.append (new Gtk.Image.from_resource ("/com/github/philip-scott/spice-up/align-bottom-symbolic"));
 
         foreach (var child in align.get_children ()) {
-            child.get_style_context ().add_class ("spice");
+            child.get_style_context ().add_class (Gtk.STYLE_CLASS_RAISED);
         }
 
         add (text_color_button);


### PR DESCRIPTION
Fixes #310

Uses the built-in style classed for raised buttons instead of custom CSS

## BEFORE

![Screenshot from 2021-12-27 12 33 36](https://user-images.githubusercontent.com/7277719/147505499-e6b84931-b328-41d3-8f6e-2769551bf0e0.png)

## AFTER

![Screenshot from 2021-12-27 12 33 20](https://user-images.githubusercontent.com/7277719/147505501-0996c39f-82e1-4dc5-836c-6279717ea415.png)