### PR TITLE
EntryCombo: use button style

### DIFF
--- a/data/stylesheet.css
+++ b/data/stylesheet.css
@@ -2,7 +2,7 @@
 @define-color colorAccent @SLATE_100;
 
 .padding-none {
-    padding: 0px;
+    padding: 0;
 }
 
 .icon-shadow {
@@ -83,10 +83,6 @@ GtkToggleButton.raised,
 
 .spice-dynamic-toolbar .raised .entry {
     padding: 0 3px;
-}
-
-.spice-dynamic-toolbar .raised.padding-none {
-    padding: 0;
 }
 
 .spice-scale {

--- a/src/Widgets/EntryCombo.vala
+++ b/src/Widgets/EntryCombo.vala
@@ -87,19 +87,23 @@ public class Spice.EntryCombo : Gtk.Box {
     private bool outsize_set = false;
     private bool strict_signal = false;
 
+    class construct {
+        set_css_name ("button");
+    }
+
     // If strict_signal == true, it will only send activated if the entry is the same as a value on the list
     public EntryCombo (bool strict_signal = false, bool alphabetize = false, bool searchable = false) {
         this.strict_signal = strict_signal;
-        get_style_context ().add_class ("spice");
         get_style_context ().add_class ("padding-none");
 
         row_map = new Gee.HashMap<string, Gtk.ListBoxRow> ();
         keys = new Gee.HashMap<string, string> ();
 
         entry_button_stack = new Gtk.Stack ();
-        entry_button_stack.margin = 3;
 
-        entry = new Gtk.Entry ();
+        entry = new Gtk.Entry () {
+            margin = 3
+        };
 
         listbox = new Gtk.ListBox ();
         listbox.margin_top = listbox.margin_bottom = 3;
@@ -108,14 +112,16 @@ public class Spice.EntryCombo : Gtk.Box {
         substitute_label = new Gtk.Label ("");
         substitute_label.halign = Gtk.Align.START;
 
-        var entry_substitute = new Gtk.Button ();
+        var entry_substitute = new Gtk.Button () {
+            can_focus = false,
+            margin= 3
+        };
         entry_substitute.get_style_context ().add_class ("flat");
         entry_substitute.add (substitute_label);
-        entry_substitute.can_focus = false;
 
         button = new Gtk.Button.from_icon_name ("pan-down-symbolic", Gtk.IconSize.MENU);
         button.get_style_context ().add_class ("flat");
-        button.get_child ().margin = 4;
+        button.get_child ().margin = 3;
         button.can_focus = false;
 
         scroll = new Gtk.ScrolledWindow (null, null);


### PR DESCRIPTION
Fixes styles of custom comboentry.

Margin was moved from the stack to the entry and button so that focus styles on the entry aren't clipped

![Screenshot from 2021-12-27 14 22 59](https://user-images.githubusercontent.com/7277719/147510961-0d1e1e13-9c3f-446d-b1bf-54ea977092e8.png)
