### PR TITLE
AppData: Add legacy RDNN to provides tag

### DIFF
--- a/data/com.github.philip_scott.spice-up.appdata.xml
+++ b/data/com.github.philip_scott.spice-up.appdata.xml
@@ -26,6 +26,8 @@
   </description>
   <provides>
     <binary>spice-up</binary>
+    <!-- Legacy RDNN -->
+    <id>com.github.philip-scott.spice-up</id>
   </provides>
   <releases>
     <release version="1.9.1" date="2021-12-31">


### PR DESCRIPTION
This should allow us to deduplicate [com.github.philip-scott.spice-up](https://appcenter.elementary.io/com.github.philip-scott.spice-up) and [com.github.philip_scott.spice-up](https://appcenter.elementary.io/com.github.philip_scott.spice-up); see also https://github.com/elementary/appcenter-web/issues/79